### PR TITLE
fix typo in home-page URL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ summary = Explore PyPI and visualize its contents in unusual and interesting way
 author = Flavio C. Coelho and colaborators
 author-email = fccoelho@gmail.com
 license = GPLv3
-home-page = http://github.com/fccoelho/pypiexplorer
+home-page = http://github.com/fccoelho/pypixplorer
 description-file = README.rst
 # Add here all kinds of additional classifiers as defined under
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
s/pypiexplorer/pypixplorer/

This is such a tiny fix you may well just want to roll it up into the next time you touch your setup cfg, but it broke the link from PyPI to the code so I thought I'd report it anyway.

Thanks for sharing your code! 