### PR TITLE
Solved: Command python graphics not working

### DIFF
--- a/pypixplore/remote.py
+++ b/pypixplore/remote.py
@@ -20,7 +20,7 @@ class Index:
         self.client = xmlrpcclient.ServerProxy(server)
         # self.cache = TinyDB(cache_path)
         self.cache = dbm.open(cache_path, 'c')
-        self.cache.reorganize()  # optimize the cache
+ #       self.cache.reorganize()  # optimize the cache
 
     @rate_limited(10)
     def _get_JSON(self, package_name, update_cache=True):
@@ -277,7 +277,7 @@ class Index:
 
         return self.get_len_request(request)
 
-    def how_many_packages_version_py(self):
+    def how_many_packages_version_py(self, n_sample=700):
         """
         print('This command can take a while, do you wish to continue? /n type Y or N')
         aux = input()
@@ -288,16 +288,17 @@ class Index:
             print('Por favor, digite S para sim ou N para não')
             self.how_many_packages_version_py()
         """
+        n_sample = int(n_sample)
 
         list_of_all_packages = self.client.list_packages()
 
         rd.shuffle(list_of_all_packages)
 
-        n_sample = 700
         all_packages = self.get_multiple_JSONs(list_of_all_packages[:n_sample])
 
         count2master = 0
         count3master = 0
+
         for key, package in all_packages.items():
 
             if len(package) > 0:
@@ -316,24 +317,22 @@ class Index:
                 count3master = count3master + 1
 
 
-        count_final = [round((count2master / n_sample) * 10),
-                       round((count3master / n_sample) * 10)]
+        count_final = [round((count2master/n_sample), 2)*10, round((count3master/n_sample), 2)*10]
 
-        self.print_graphics(count_final[0], count_final[1], n_sample)
+        return count_final
 
-    def print_graphics(self, python2, python3, n_sample):
+    def print_graphics(self, python2, python3):
         count_python2 = ""
         count_python3 = ""
 
-        for i in range(0, python2):
+        for i in range(0, round(python2)):
             count_python2 = count_python2 + "*"
-        for i in range(0, python3):
+        for i in range(0, round(python3)):
             count_python3 = count_python3 + "*"
 
-        print('             |')
-        print('Python 2.x.x |{} {}%'.format(count_python2, python2 * 10))
-        print('             |')
-        print('             |')
-        print('Python 3.x.x |{} {}%'.format(count_python3, python3 * 10))
-        print('             |')
-        print('Sample error is 5% and confidence level of 99%')
+        string_to_print = '''
+        Python 2.x.x|{} {}%
+        Python 3.x.x|{} {}%
+        '''.format(count_python2, python2*10, count_python3, python3*10)
+
+        return string_to_print

--- a/pypixplore/skeleton.py
+++ b/pypixplore/skeleton.py
@@ -123,7 +123,8 @@ def parse_args(args):
     parser.add_argument(
         '-pv',
         '--python_versions',
-        action='store_true',
+        nargs=1,
+        metavar="<n_sample>",
         help="Return a graph with the numbers of packages that run on Python 2x.x and Python 3.x.x",
     )
 
@@ -206,8 +207,9 @@ def main(args):
     elif args.tree is not None:
         print('{}\n(note: only two levels shown)'.format(ip.dependency_graph(package_name=args.tree[0])))
 
-    elif args.python_versions:
-        pprint(ind.how_many_packages_version_py())
+    elif args.python_versions is not None:
+        result = ind.how_many_packages_version_py(n_sample=args.python_versions[0])
+        pprint(ind.print_graphics(result[0], result[1]))
 
     elif args.release_series is not None:
         pprint(ind.release_series(package_name=args.release_series[0]))

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -89,3 +89,13 @@ class Tests:
         out = index.get_multiple_JSONs(l[:100])
         assert isinstance(out, dict)
         assert isinstance(out.get(l[5]), dict)
+
+    def test_print_graphics(self, index):
+        out = index.print_graphics(2, 3)
+        assert "**" in out and "***" in out
+
+    def test_how_many_packages_version_py(self, index):
+        out = index.how_many_packages_version_py(n_sample=150)
+        assert isinstance(out, list)
+        assert out[0] > 0
+        assert out[1] > 0


### PR DESCRIPTION
With the help of @blankluke and @JoaoCarabetta, now the Python Graphics are working and we have test for print_graphics and test_how_many_packages_version_py.

I had a problem with this line of command "self.cache.reorganize()  # optimize the cache" in remote.py. That is why I commented it, but I don't know if it is a local problem, so I didn't open a bug report.